### PR TITLE
Fix ambiguous function overloads & Base64Encoder types

### DIFF
--- a/types/0.5.0/fs.luau
+++ b/types/0.5.0/fs.luau
@@ -49,19 +49,19 @@ type FileHandle = {
     --- @param bytes If true, the function will return a `buffer` instead of a `string`.
     --- @throws IO Error
     read:
-        & ((self: FileHandle, amount: number?) -> string)
-        & ((self: FileHandle, amount: number?, bytes: false?) -> string)
+        & ((self: FileHandle, amount: number?, bytes: nil) -> string)
+        & ((self: FileHandle, amount: number?, bytes: false) -> string)
         & ((self: FileHandle, amount: number?, bytes: true) -> buffer)
-        & ((self: FileHandle, amount: number?, bytes: boolean?) -> string | buffer),
+        & ((self: FileHandle, amount: number?, bytes: boolean) -> string | buffer),
     --- Read the contents of the file synchronously.
     --- @param amount The amount of bytes to read, if not provided, it will read until EOF or luau limit
     --- @param bytes If true, the function will return a `buffer` instead of a `string`.
     --- @throws IO Error
     readSync:
-        & ((self: FileHandle, amount: number?) -> string)
-        & ((self: FileHandle, amount: number?, bytes: false?) -> string)
+        & ((self: FileHandle, amount: number?, bytes: nil) -> string)
+        & ((self: FileHandle, amount: number?, bytes: false) -> string)
         & ((self: FileHandle, amount: number?, bytes: true) -> buffer)
-        & ((self: FileHandle, amount: number?, bytes: boolean?) -> string | buffer),
+        & ((self: FileHandle, amount: number?, bytes: boolean) -> string | buffer),
     --- Write the contents to the file.
     --- @param contents The contents to write to the file.
     --- @throws IO Error
@@ -167,8 +167,8 @@ type FileSystemLib = {
     --- @default_param bytes false
     --- @throws IO Error
     readFile:
-        & ((path: string) -> string)
-        & ((path: string, bytes: false?) -> string)
+        & ((path: string, bytes: nil) -> string)
+        & ((path: string, bytes: false) -> string)
         & ((path: string, bytes: true) -> buffer)
         & ((path: string, bytes: boolean) -> string | buffer),
     --- Read the contents of a file from the provided path synchronously.
@@ -177,8 +177,8 @@ type FileSystemLib = {
     --- @default_param bytes false
     --- @throws IO Error
     readFileSync:
-        & ((path: string) -> string)
-        & ((path: string, bytes: false?) -> string)
+        & ((path: string, bytes: nil) -> string)
+        & ((path: string, bytes: false) -> string)
         & ((path: string, bytes: true) -> buffer)
         & ((path: string, bytes: boolean) -> string | buffer),
     --- Get directory entries from the provided path.

--- a/types/0.5.0/io.luau
+++ b/types/0.5.0/io.luau
@@ -12,10 +12,10 @@ type IoReadable = {
     --- @default_param bytes true
     --- @throws Reader Error
     read:
-        & ((self: IoReadable, amount: number?) -> buffer)
-        & ((self: IoReadable, amount: number?, bytes: true?) -> buffer)
+        & ((self: IoReadable, amount: number?, bytes: nil) -> buffer)
+        & ((self: IoReadable, amount: number?, bytes: true) -> buffer)
         & ((self: IoReadable, amount: number?, bytes: false) -> string)
-        & ((self: IoReadable, amount: number?, bytes: boolean?) -> string | buffer),
+        & ((self: IoReadable, amount: number?, bytes: boolean) -> string | buffer),
     readu8: (self: IoReadable) -> number,
     readu16: (self: IoReadable) -> number,
     readu32: (self: IoReadable) -> number,
@@ -56,10 +56,10 @@ type BufferStream = {
     --- @default_param bytes true
     --- @throws Reader Error
     read:
-        & ((self: BufferStream, amount: number?) -> buffer)
-        & ((self: BufferStream, amount: number?, bytes: true?) -> buffer)
+        & ((self: BufferStream, amount: number?, bytes: nil) -> buffer)
+        & ((self: BufferStream, amount: number?, bytes: true) -> buffer)
         & ((self: BufferStream, amount: number?, bytes: false) -> string)
-        & ((self: BufferStream, amount: number?, bytes: boolean?) -> string | buffer),
+        & ((self: BufferStream, amount: number?, bytes: boolean) -> string | buffer),
     --- @param data The data to write to the stream.
     --- @throws Writer Error
     write: (self: BufferStream, data: string | buffer) -> (),
@@ -87,10 +87,10 @@ type BufferSink = {
     --- @default_param bytes true
     --- @throws Memory Error
     flush:
-        & ((self: BufferSink) -> buffer)
-        & ((self: BufferSink, bytes: true?) -> buffer)
+        & ((self: BufferSink, bytes: nil) -> buffer)
+        & ((self: BufferSink, bytes: true) -> buffer)
         & ((self: BufferSink, bytes: false) -> string)
-        & ((self: BufferSink, bytes: boolean?) -> string | buffer),
+        & ((self: BufferSink, bytes: boolean) -> string | buffer),
     --- @param data The data to write to write.
     --- @throws Memory Error
     write: (self: BufferSink, data: string | buffer) -> (),

--- a/types/0.5.0/net.luau
+++ b/types/0.5.0/net.luau
@@ -469,9 +469,10 @@ type NetworkLib = {
         --- @throws Network Error
         request:
             & ((host: string) -> HttpResponse<string>)
-            & ((host: string, opts: HttpRequestOptions?, bytes: false?) -> HttpResponse<string>)
+            & ((host: string, opts: HttpRequestOptions?, bytes: nil) -> HttpResponse<string>)
+            & ((host: string, opts: HttpRequestOptions?, bytes: false) -> HttpResponse<string>)
             & ((host: string, opts: HttpRequestOptions?, bytes: true) -> HttpResponse<buffer>)
-            & ((host: string, opts: HttpRequestOptions?, bytes: boolean?) -> HttpResponse<string | buffer>),
+            & ((host: string, opts: HttpRequestOptions?, bytes: boolean) -> HttpResponse<string | buffer>),
         -- Creates a new WebSocket connection.
         --- @param host The host to connect to.
         --- @param opts The options for the WebSocket.

--- a/types/0.5.0/process.luau
+++ b/types/0.5.0/process.luau
@@ -80,9 +80,10 @@ type ProcessLib = {
     run: 
         & ((exec: string) -> ProcessRunResult<string>)
         & ((exec: string, args: {string}?) -> ProcessRunResult<string>)
-        & ((exec: string, args: {string}?, opts: ProcessOptions?, bytes: false?) -> ProcessRunResult<string?>)
+        & ((exec: string, args: {string}?, opts: ProcessOptions?, bytes: nil) -> ProcessRunResult<string?>)
+        & ((exec: string, args: {string}?, opts: ProcessOptions?, bytes: false) -> ProcessRunResult<string?>)
         & ((exec: string, args: {string}?, opts: ProcessOptions?, bytes: true) -> ProcessRunResult<buffer?>)
-        & ((exec: string, args: {string}?, opts: ProcessOptions?, bytes: boolean?) -> ProcessRunResult<string | buffer?>),
+        & ((exec: string, args: {string}?, opts: ProcessOptions?, bytes: boolean) -> ProcessRunResult<string | buffer?>),
     --- Exits the process with the given code.
     --- @param code The exit code.
     exit: (code: number) -> never,

--- a/types/0.5.0/serde.luau
+++ b/types/0.5.0/serde.luau
@@ -65,26 +65,21 @@ type YamlEncoder = {
     decode: (yaml: string | buffer) -> YamlOuput,
 }
 
-type CompressionFn =
-    & ((raw: string) -> string)
-    & ((raw: buffer) -> buffer)
-    & ((raw: string | buffer) -> string | buffer)
-
-
-type DecompressionFn =
-    & ((compressed: string) -> string)
-    & ((compressed: buffer) -> buffer)
-    & ((compressed: string | buffer) -> string | buffer)
-
 type Base64Encoder = {
     --- Encodes a string to Base64.
     --- @param value The data to encode.
     --- @throws Memory Error
-    encode: CompressionFn,
+    encode:
+        & ((value: string) -> string)
+        & ((value: buffer) -> buffer)
+        & ((value: string | buffer) -> string | buffer),
     --- Decodes a Base64 string.
     --- @param base64 The Base64 value to decode.
     --- @throws Memory Error
-    decode: DecompressionFn,
+    decode:
+        & ((base64: string) -> string)
+        & ((base64: buffer) -> buffer)
+        & ((base64: string | buffer) -> string | buffer),
 }
 
 export type SerdeGenericCompressionOptions = {
@@ -92,10 +87,20 @@ export type SerdeGenericCompressionOptions = {
     level: number?,
 }
 
+type CompressionFn =
+    & ((raw: string) -> string)
+    & ((raw: buffer) -> buffer)
+    & ((raw: string | buffer) -> string | buffer)
+
 type AdvancedCompressionFn =
     & ((raw: string, opts: SerdeGenericCompressionOptions?) -> string)
     & ((raw: buffer, opts: SerdeGenericCompressionOptions?) -> buffer)
     & ((raw: string | buffer, opts: SerdeGenericCompressionOptions?) -> string | buffer)
+    
+type DecompressionFn =
+    & ((compressed: string) -> string)
+    & ((compressed: buffer) -> buffer)
+    & ((compressed: string | buffer) -> string | buffer)
 
 type GenericCompressor = {
     --- @param raw The data to compress. If `raw` is a `buffer`, the function will return a `buffer` instead of a `string`.

--- a/types/0.5.0/serde.luau
+++ b/types/0.5.0/serde.luau
@@ -65,21 +65,26 @@ type YamlEncoder = {
     decode: (yaml: string | buffer) -> YamlOuput,
 }
 
+type CompressionFn =
+    & ((raw: string) -> string)
+    & ((raw: buffer) -> buffer)
+    & ((raw: string | buffer) -> string | buffer)
+
+
+type DecompressionFn =
+    & ((compressed: string) -> string)
+    & ((compressed: buffer) -> buffer)
+    & ((compressed: string | buffer) -> string | buffer)
+
 type Base64Encoder = {
     --- Encodes a string to Base64.
     --- @param value The data to encode.
     --- @throws Memory Error
-    encode:
-        & ((value: string) -> string)
-        & ((value: buffer) -> buffer)
-        & ((value: string | buffer) -> string | buffer),
+    encode: CompressionFn,
     --- Decodes a Base64 string.
     --- @param base64 The Base64 value to decode.
     --- @throws Memory Error
-    decode:
-        & ((base64: string) -> string)
-        & ((base64: buffer) -> buffer)
-        & ((base64: string | buffer) -> string | buffer),
+    decode: DecompressionFn,
 }
 
 export type SerdeGenericCompressionOptions = {
@@ -87,20 +92,10 @@ export type SerdeGenericCompressionOptions = {
     level: number?,
 }
 
-type CompressionFn =
-    & ((raw: string) -> string)
-    & ((raw: buffer) -> buffer)
-    & ((raw: string | buffer) -> string | buffer)
-
 type AdvancedCompressionFn =
     & ((raw: string, opts: SerdeGenericCompressionOptions?) -> string)
     & ((raw: buffer, opts: SerdeGenericCompressionOptions?) -> buffer)
     & ((raw: string | buffer, opts: SerdeGenericCompressionOptions?) -> string | buffer)
-    
-type DecompressionFn =
-    & ((compressed: string) -> string)
-    & ((compressed: buffer) -> buffer)
-    & ((compressed: string | buffer) -> string | buffer)
 
 type GenericCompressor = {
     --- @param raw The data to compress. If `raw` is a `buffer`, the function will return a `buffer` instead of a `string`.

--- a/types/0.5.0/serde.luau
+++ b/types/0.5.0/serde.luau
@@ -96,7 +96,7 @@ type AdvancedCompressionFn =
     & ((raw: string, opts: SerdeGenericCompressionOptions?) -> string)
     & ((raw: buffer, opts: SerdeGenericCompressionOptions?) -> buffer)
     & ((raw: string | buffer, opts: SerdeGenericCompressionOptions?) -> string | buffer)
-    
+
 type DecompressionFn =
     & ((compressed: string) -> string)
     & ((compressed: buffer) -> buffer)

--- a/types/0.5.0/serde.luau
+++ b/types/0.5.0/serde.luau
@@ -65,20 +65,26 @@ type YamlEncoder = {
     decode: (yaml: string | buffer) -> YamlOuput,
 }
 
+type CompressionFn =
+    & ((raw: string) -> string)
+    & ((raw: buffer) -> buffer)
+    & ((raw: string | buffer) -> string | buffer)
+
+
+type DecompressionFn =
+    & ((compressed: string) -> string)
+    & ((compressed: buffer) -> buffer)
+    & ((compressed: string | buffer) -> string | buffer)
+
 type Base64Encoder = {
     --- Encodes a string to Base64.
     --- @param value The data to encode.
     --- @throws Memory Error
-    encode:
-        & ((value: string) -> string)
-        & ((value: buffer) -> buffer)
-        & ((value: string | buffer) -> string | buffer),
+    encode: CompressionFn,
     --- Decodes a Base64 string.
     --- @param base64 The Base64 value to decode.
     --- @throws Memory Error
-    decode:
-        & ((base64: string) -> string)
-        & ((base64: string | buffer) -> string | buffer),
+    decode: DecompressionFn,
 }
 
 export type SerdeGenericCompressionOptions = {
@@ -86,21 +92,10 @@ export type SerdeGenericCompressionOptions = {
     level: number?,
 }
 
-type CompressionFn =
-    & ((raw: string) -> string)
-    & ((raw: buffer) -> buffer)
-    & ((raw: string | buffer) -> string | buffer)
-
-
 type AdvancedCompressionFn =
     & ((raw: string, opts: SerdeGenericCompressionOptions?) -> string)
     & ((raw: buffer, opts: SerdeGenericCompressionOptions?) -> buffer)
     & ((raw: string | buffer, opts: SerdeGenericCompressionOptions?) -> string | buffer)
-
-type DecompressionFn =
-    & ((compressed: string) -> string)
-    & ((compressed: buffer) -> buffer)
-    & ((compressed: string | buffer) -> string | buffer)
 
 type GenericCompressor = {
     --- @param raw The data to compress. If `raw` is a `buffer`, the function will return a `buffer` instead of a `string`.


### PR DESCRIPTION
With the current types, Luau's new solver throws a type error of `Calling function [...] with argument pack [...] is ambiguous` whenever calling any of the functions with modified type signatures.

This also fixes invalid decode types for `Base64Encoder`, which didn't have an overload for returning a buffer when a buffer is passed.